### PR TITLE
Show resolving URL beans

### DIFF
--- a/gh-6813/README.md
+++ b/gh-6813/README.md
@@ -1,0 +1,7 @@
+Starting this application takes forever, as something in
+spring-boot-starter-actuator tries to resolve  hostnames
+of all URL beans (see strace).
+
+The application will start if either not spring-boot-starter-actuator
+is on the class path, the List<URL> is not a managed bean or
+using spring-boot-1.3.7.

--- a/gh-6813/pom.xml
+++ b/gh-6813/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>de.malkusch</groupId>
+	<artifactId>issue6813</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.4.0.RELEASE</version>
+	</parent>
+
+	<properties>
+		<java-version>1.8</java-version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java-version}</source>
+					<target>${java-version}</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/gh-6813/src/main/java/de/malkusch/issue6813/Application.java
+++ b/gh-6813/src/main/java/de/malkusch/issue6813/Application.java
@@ -1,0 +1,13 @@
+package de.malkusch.issue6813;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/gh-6813/src/main/java/de/malkusch/issue6813/Config.java
+++ b/gh-6813/src/main/java/de/malkusch/issue6813/Config.java
@@ -1,0 +1,28 @@
+package de.malkusch.issue6813;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class Config {
+
+    @Bean
+    List<URL> list() {
+        return IntStream.range(0, 10000).mapToObj(this::buildURL).collect(Collectors.toList());
+    }
+
+    private URL buildURL(int i) {
+        try {
+            return new URL(String.format("http://www%d.example.org", i));
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
Starting this application takes forever, as something in
spring-boot-starter-actuator tries to resolve  hostnames
of all URL beans (see strace).

The application will start if either not spring-boot-starter-actuator
is on the class path, the List<URL> is not a managed bean or
using spring-boot-1.3.7.

See also: spring-projects/spring-boot#6813